### PR TITLE
schema: Add new add attributes for timezone, locale and keyboard settings

### DIFF
--- a/master/schema/puavo.ldif
+++ b/master/schema/puavo.ldif
@@ -405,7 +405,7 @@ olcObjectClasses: {5}( 1.3.6.1.4.1.27208.1.1.2.6 NAME 'puavoEduOrg' AUXILIARY
  esktopPublicKey $ puavoRemoteDesktopPrivateKey $ puavoDeviceAutoPowerOffMode 
  $ puavoDeviceOnHour $ puavoDeviceOffHour $ puavoClassNamingScheme $ puavoVers
  ion $ puavoEduOrgAbbreviation $ puavoDeviceImage $ puavoWlanSSID $ puavoWlanC
- hannel $ puavoAllowGuest $ puavoPersonalDevice $ puavoActiveService $ puavoExternalFeed $ puavoTag $ 
+ hannel $ puavoAllowGuest $ puavoPersonalDevice $ puavoActiveService $ puavoExternalFeed $ puavoTag
   $ puavoTimezone $ puavoLocale $ puavoKeyboardLayout $ puavoKeyboardVariant) )
 olcObjectClasses: {6}( 1.3.6.1.4.1.27208.1.1.2.7 NAME 'puavoShare' AUXILIARY M
  UST ( puavoId $ puavoServer ) )


### PR DESCRIPTION
With the new attributes Puavo can be used to configure devices the same
way as normal linux installers do. Keyboard setting still require some
additional parameters that need to be added.
